### PR TITLE
Find rules rather than use a hard-coded list

### DIFF
--- a/lib/App/PerlNitpick/Nitpicker.pm
+++ b/lib/App/PerlNitpick/Nitpicker.pm
@@ -20,38 +20,13 @@ has inplace => (
     isa => 'Bool',
 );
 
-use PPI::Document;
-
-# use Module::Find qw(useall);
-# my @rules = sort { $a cmp $b } useall App::PerlNitpick::Rule;
-
-# perl -Mlib=local -Ilib -MModule::Find=findallmod -E 'say "use $_;" for findallmod("App::PerlNitpick::Rule")'
-use App::PerlNitpick::Rule::AppendUnimportStatement;
-use App::PerlNitpick::Rule::DedupeIncludeStatements;
-use App::PerlNitpick::Rule::QuoteSimpleStringWithSingleQuote;
-use App::PerlNitpick::Rule::RemoveEffectlessUTF8Pragma;
-use App::PerlNitpick::Rule::RemoveTrailingWhitespace;
-use App::PerlNitpick::Rule::RemoveUnusedImport;
-use App::PerlNitpick::Rule::RemoveUnusedInclude;
-use App::PerlNitpick::Rule::RemoveUnusedVariables;
-use App::PerlNitpick::Rule::RewriteHeredocAsQuotedString;
-use App::PerlNitpick::Rule::RewriteWithAssignmentOperators;
-
-my @rules = qw(
-    AppendUnimportStatement
-    DedupeIncludeStatements
-    QuoteSimpleStringWithSingleQuote
-    RemoveEffectlessUTF8Pragma
-    RemoveTrailingWhitespace
-    RemoveUnusedImport
-    RemoveUnusedInclude
-    RemoveUnusedVariables
-    RewriteHeredocAsQuotedString
-    RewriteWithAssignmentOperators
-);
+use Module::Find qw( findallmod );
+use PPI::Document ();
 
 sub list_rules {
     my ($class) = @_;
+    my @found = sort { $a cmp $b } findallmod( 'App::PerlNitpick::Rule' );
+    my @rules = map { $_ =~ s{App::PerlNitpick::Rule::}{}; $_; } @found;
     for my $rule (@rules) {
         $rule =~ s/\A .+ :://x;
         print "$rule\n";
@@ -65,6 +40,8 @@ sub rewrite {
     my $ppi = PPI::Document->new( $self->file ) or return;
     for my $rule (@{$self->rules}) {
         my $rule_class = 'App::PerlNitpick::Rule::' . $rule;
+        eval "require $rule_class" || die;
+
         $ppi = $rule_class->new->rewrite($ppi);
     }
     if ($self->inplace) {


### PR DESCRIPTION
This reworks some commented code. It does a few things:

1) It only loads required rules, which could make it slightly faster
2) It allows for other modules in the App::PerlNitpick::Rule namespace
   to be uploaded by other authors
